### PR TITLE
Bump bblfsh/bblfshd to v2.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@ The changes listed under `Unreleased` section have landed in master but are not 
 
 ### Components
 
-- `bblfsh/bblfshd` has been updated to [v2.15.0](https://github.com/bblfsh/bblfshd/releases/tag/v2.15.0).
-- `bblfsh/web` has been updated to [v0.11.4](https://github.com/bblfsh/web/releases/tag/v0.11.4).
-	- Use the same logging level as the other components reading `LOG_LEVEL` enviroment value (default: `info`) (([#263](https://github.com/src-d/sourced-ce/pull/263)).
 - `srcd/sourced-ui` has been updated to [v0.8.1](https://github.com/src-d/sourced-ui/releases/tag/v0.8.1).
+
+Babelfish components were updated in order to use the same logging level as the other components reading the `LOG_LEVEL` enviroment value (default: `info`):
+- `bblfsh/bblfshd` has been updated to [v2.16.1](https://github.com/bblfsh/bblfshd/releases/tag/v2.16.1) (([#264](https://github.com/src-d/sourced-ce/pull/264)).
+- `bblfsh/web` has been updated to [v0.11.4](https://github.com/bblfsh/web/releases/tag/v0.11.4) (([#263](https://github.com/src-d/sourced-ce/pull/263)).
 
 
 ### Fixed

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,11 +29,13 @@ x-superset-env: &superset-env
 
 services:
   bblfsh:
-    image: bblfsh/bblfshd:v2.15.0-drivers
+    image: bblfsh/bblfshd:v2.16.1-drivers-2019-10-29
     restart: unless-stopped
     privileged: true
     ports:
       - 9432:9432
+    environment:
+      LOG_LEVEL: ${LOG_LEVEL-info}
 
   gitcollector:
     image: srcd/gitcollector:v0.0.4


### PR DESCRIPTION
required by https://github.com/src-d/backlog/issues/1485
same as in https://github.com/src-d/sourced-ce/pull/263 and https://github.com/src-d/sourced-ce/pull/159

`bblfsh/bblfshd` has been updated to [v2.16.1](https://github.com/bblfsh/bblfshd/releases/tag/v2.16.1) in order to use the same logging level as the other components reading `LOG_LEVEL` environment value (default: `info`)

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file